### PR TITLE
Add min-release-age to prevent supply chain attacks

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=1


### PR DESCRIPTION
See https://chia-network.atlassian.net/browse/SEC-1019 and #security_chat for context

## Summary

Adds `min-release-age=1` to `.npmrc`, which tells npm to only resolve package versions published more than 1 day ago. Most malicious package versions are detected and yanked within hours, so a 24-hour delay filters out smash-and-grab supply chain attacks.

Requires npm >= 11.10.0 (ships with Node.js >= 24.14.1). Older npm versions silently ignore the setting.

Made with [Cursor](https://cursor.com)