### PR TITLE
use string for big number

### DIFF
--- a/src/hooks/useRpcUi.tsx
+++ b/src/hooks/useRpcUi.tsx
@@ -16,9 +16,10 @@ export function useRpcUi() {
 
     const [fingerprint, setFingerprint] = useState(0);
     const [fingerprints, setFingerprints] = useState<string>('');
-    const [amount, setAmount] = useState(0);
+    // Keep as strings so mojo values above 2^53-1 aren't coerced/rounded.
+    const [amount, setAmount] = useState('0');
     const [count, setCount] = useState(1);
-    const [fee, setFee] = useState(0);
+    const [fee, setFee] = useState('0');
     const [number, setNumber] = useState(50);
     const [index, setIndex] = useState(0);
     const [startIndex, setStartIndex] = useState(0);
@@ -170,8 +171,8 @@ export function useRpcUi() {
         ],
         chia_sendTransaction: [
             numberOption('Wallet Id', walletId, setWalletId),
-            numberOption('Amount', amount, setAmount),
-            numberOption('Fee', fee, setFee),
+            stringOption('Amount', amount, setAmount),
+            stringOption('Fee', fee, setFee),
             stringOption('Address', address, setAddress),
             stringOption('Memos', memos, setMemos),
             booleanOption(
@@ -306,7 +307,7 @@ export function useRpcUi() {
             ),
         ],
         chia_cancelOffer: [
-            numberOption('Fee', fee, setFee),
+            stringOption('Fee', fee, setFee),
             stringOption('Trade Id', tradeId, setTradeId),
             booleanOption('Secure', secure, setSecure),
             submitButton('Cancel Offer', () =>
@@ -324,7 +325,7 @@ export function useRpcUi() {
             ),
         ],
         chia_takeOffer: [
-            numberOption('Fee', fee, setFee),
+            stringOption('Fee', fee, setFee),
             stringOption('Offer Data', offerData, setOfferData),
             submitButton('Take Offer', () =>
                 rpc.takeOffer({ fee, offer: offerData })
@@ -349,8 +350,8 @@ export function useRpcUi() {
 
         // CATs
         chia_createNewCATWallet: [
-            numberOption('Amount', amount, setAmount),
-            numberOption('Fee', fee, setFee),
+            stringOption('Amount', amount, setAmount),
+            stringOption('Fee', fee, setFee),
             submitButton('Create New CAT Wallet', () =>
                 rpc.createNewCatWallet({ amount, fee })
             ),
@@ -370,8 +371,8 @@ export function useRpcUi() {
         chia_spendCAT: [
             numberOption('Wallet Id', walletId, setWalletId),
             stringOption('Address', address, setAddress),
-            numberOption('Amount', amount, setAmount),
-            numberOption('Fee', fee, setFee),
+            stringOption('Amount', amount, setAmount),
+            stringOption('Fee', fee, setFee),
             booleanOption(
                 'Wait For Confirmation',
                 waitForConfirmation,
@@ -429,7 +430,7 @@ export function useRpcUi() {
             numberOption('Edition Number', editionNumber, setEditionNumber),
             numberOption('Edition Count', editionCount, setEditionCount),
             stringOption('DID ID', didId, setDidId),
-            numberOption('Fee', fee, setFee),
+            stringOption('Fee', fee, setFee),
             submitButton('Mint NFT', () =>
                 rpc.mintNft({
                     walletId,
@@ -459,7 +460,7 @@ export function useRpcUi() {
             numberOption('Wallet Id', walletId, setWalletId),
             stringOption('NFT Coin Ids', nftCoinIds, setNftCoinIds),
             stringOption('Address', address, setAddress),
-            numberOption('Fee', fee, setFee),
+            stringOption('Fee', fee, setFee),
             submitButton('Transfer NFT', () =>
                 rpc.transferNft({
                     walletId,
@@ -484,8 +485,8 @@ export function useRpcUi() {
 
         // DIDs
         chia_createNewDIDWallet: [
-            numberOption('Amount', amount, setAmount),
-            numberOption('Fee', fee, setFee),
+            stringOption('Amount', amount, setAmount),
+            stringOption('Fee', fee, setFee),
             numberOption(
                 'Number of Backup Dids Needed',
                 backupDidsNeeded,
@@ -515,7 +516,7 @@ export function useRpcUi() {
             stringOption('NFT Coin Ids', nftCoinIds, setNftCoinIds),
             stringOption('Launcher Id', launcherId, setLauncherId),
             stringOption('DID', did, setDid),
-            numberOption('Fee', fee, setFee),
+            stringOption('Fee', fee, setFee),
             submitButton('Set NFT DID', () =>
                 rpc.setNftDid({
                     walletId,

--- a/src/hooks/useRpcUi.tsx
+++ b/src/hooks/useRpcUi.tsx
@@ -7,6 +7,7 @@ import {
 } from '@mui/material';
 import { useState } from 'react';
 import { useJsonRpc } from '../contexts/JsonRpcContext';
+import { jsonParseSafeIntegers } from '../utils/jsonSafe';
 
 export function useRpcUi() {
     const rpc = useJsonRpc();
@@ -299,8 +300,8 @@ export function useRpcUi() {
                 rpc.createOfferForIds({
                     disableJSONFormatting: disableJsonFormatting,
                     validateOnly,
-                    offer: JSON.parse(offer || '{}'),
-                    driverDict: JSON.parse(driverDict || '{}'),
+                    offer: jsonParseSafeIntegers(offer || '{}'),
+                    driverDict: jsonParseSafeIntegers(driverDict || '{}'),
                 })
             ),
         ],

--- a/src/types/rpc/CancelOffer.ts
+++ b/src/types/rpc/CancelOffer.ts
@@ -1,7 +1,7 @@
 export interface CancelOfferRequest {
     tradeId: string;
     secure: boolean;
-    fee: number;
+    fee: string;
 }
 
 export interface CancelOfferResponse {

--- a/src/types/rpc/CreateNewCatWallet.ts
+++ b/src/types/rpc/CreateNewCatWallet.ts
@@ -1,8 +1,8 @@
 import { WalletType } from '../WalletType';
 
 export interface CreateNewCatWalletRequest {
-    amount: number;
-    fee: number;
+    amount: string;
+    fee: string;
 }
 
 export interface CreateNewCatWalletResponse {

--- a/src/types/rpc/CreateNewDidWallet.ts
+++ b/src/types/rpc/CreateNewDidWallet.ts
@@ -1,8 +1,8 @@
 import { WalletType } from '../WalletType';
 
 export interface CreateNewDidWalletRequest {
-    amount: number;
-    fee: number;
+    amount: string;
+    fee: string;
     backupDids: string[];
     numOfBackupIdsNeeded: number;
 }

--- a/src/types/rpc/MintNft.ts
+++ b/src/types/rpc/MintNft.ts
@@ -14,7 +14,7 @@ export interface MintNftRequest {
     editionNumber: number,
     editionCount: number,
     didId: string,
-    fee: number,
+    fee: string,
 }
 
 export type MintNftResponse = NftInfo;

--- a/src/types/rpc/SendTransaction.ts
+++ b/src/types/rpc/SendTransaction.ts
@@ -1,8 +1,8 @@
 import { TransactionRecord } from '../TransactionRecord';
 
 export interface SendTransactionRequest {
-    amount: number;
-    fee: number;
+    amount: string;
+    fee: string;
     address: string;
     walletId?: number;
     waitForConfirmation?: boolean;

--- a/src/types/rpc/SetNftDid.ts
+++ b/src/types/rpc/SetNftDid.ts
@@ -5,7 +5,7 @@ export interface SetNftDidRequest {
     nftLauncherId: string;
     nftCoinIds: string[];
     did: string;
-    fee: number;
+    fee: string;
 }
 
 export interface SetNftDidResponse {

--- a/src/types/rpc/SpendCat.ts
+++ b/src/types/rpc/SpendCat.ts
@@ -3,8 +3,8 @@ import { TransactionRecord } from '../TransactionRecord';
 export interface SpendCatRequest {
     walletId: number;
     address: string;
-    amount: number;
-    fee: number;
+    amount: string;
+    fee: string;
     memos?: string[];
     waitForConfirmation?: boolean;
 }

--- a/src/types/rpc/TakeOffer.ts
+++ b/src/types/rpc/TakeOffer.ts
@@ -2,7 +2,7 @@ import { TradeRecord } from '../TradeRecord';
 
 export interface TakeOfferRequest {
     offer: string;
-    fee: number;
+    fee: string;
 }
 
 export interface TakeOfferResponse {

--- a/src/types/rpc/TransferNft.ts
+++ b/src/types/rpc/TransferNft.ts
@@ -4,7 +4,7 @@ export interface TransferNftRequest {
     walletId: number;
     nftCoinIds: string[];
     targetAddress: string;
-    fee: number;
+    fee: string;
 }
 
 export interface TransferNftResponse {

--- a/src/utils/jsonSafe.ts
+++ b/src/utils/jsonSafe.ts
@@ -1,0 +1,22 @@
+const MAX_SAFE = BigInt(Number.MAX_SAFE_INTEGER);
+const MIN_SAFE = BigInt(Number.MIN_SAFE_INTEGER);
+
+/**
+ * JSON.parse that keeps integers outside ±(2^53-1) as strings so precision
+ * isn't lost. Safe integers stay numbers.
+ */
+export function jsonParseSafeIntegers(text: string): any {
+    return JSON.parse(
+        text.replace(/([:\[,]\s*)(-?\d+)(\s*[,\]}])/g, (full, pre, digits, post) => {
+            try {
+                const value = BigInt(digits);
+                if (value > MAX_SAFE || value < MIN_SAFE) {
+                    return `${pre}"${digits}"${post}`;
+                }
+            } catch {
+                // leave unchanged
+            }
+            return full;
+        })
+    );
+}


### PR DESCRIPTION
bigints are not supported by walletConnect so this resolves anything over the max safe to be a string

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how monetary amounts and fees are sent on wallet RPC calls; incorrect parsing or backend expectations could affect transaction amounts, though the intent is to fix rounding bugs on large values.
> 
> **Overview**
> **Prevents precision loss** for Chia mojo amounts and fees above JavaScript’s `Number.MAX_SAFE_INTEGER` (2^53−1), which WalletConnect cannot represent as bigints.
> 
> RPC request types for **send transaction**, **spend CAT**, **offers** (cancel/take), **CAT/DID wallet creation**, **NFT mint/transfer**, and **set NFT DID** now type `amount` and/or `fee` as **`string`** instead of **`number`**. The RPC debug UI in `useRpcUi` keeps `amount`/`fee` in string state and uses text fields instead of numeric inputs for those flows.
> 
> Adds **`jsonParseSafeIntegers`** in `jsonSafe.ts` and uses it when parsing **offer** and **driver dict** JSON for `createOfferForIds`, so integers outside the safe range stay as strings after parse instead of being rounded.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66ff2244af3bd4996aab2ea745651e25ec273ff8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->