### PR TITLE
use json bigint for large numbers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,12 +16,14 @@
                 "@types/qrcode": "^1.5.5",
                 "@walletconnect/sign-client": "^2.10.0",
                 "@walletconnect/utils": "^2.10.0",
+                "json-bigint": "^1.0.0",
                 "qrcode": "^1.5.4",
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0",
                 "react-syntax-highlighter": "^16.1.0"
             },
             "devDependencies": {
+                "@types/json-bigint": "^1.0.4",
                 "@types/react": "^18.3.24",
                 "@types/react-dom": "^18.3.7",
                 "@types/react-syntax-highlighter": "^15.5.6",
@@ -1900,6 +1902,13 @@
                 "@types/unist": "*"
             }
         },
+        "node_modules/@types/json-bigint": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@types/json-bigint/-/json-bigint-1.0.4.tgz",
+            "integrity": "sha512-ydHooXLbOmxBbubnA7Eh+RpBzuaIiQjh8WGJYQB50JFGFrdxW7JzVlyEV7fAXw0T2sqJ1ysTneJbiyNLqZRAag==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@types/json-schema": {
             "version": "7.0.15",
             "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -2968,6 +2977,15 @@
             "resolved": "https://registry.npmjs.org/base-x/-/base-x-5.0.1.tgz",
             "integrity": "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==",
             "license": "MIT"
+        },
+        "node_modules/bignumber.js": {
+            "version": "9.3.1",
+            "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+            "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+            "license": "MIT",
+            "engines": {
+                "node": "*"
+            }
         },
         "node_modules/blakejs": {
             "version": "1.2.1",
@@ -4232,6 +4250,15 @@
             },
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/json-bigint": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+            "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+            "license": "MIT",
+            "dependencies": {
+                "bignumber.js": "^9.0.0"
             }
         },
         "node_modules/json-buffer": {

--- a/package.json
+++ b/package.json
@@ -18,12 +18,14 @@
         "@types/qrcode": "^1.5.5",
         "@walletconnect/sign-client": "^2.10.0",
         "@walletconnect/utils": "^2.10.0",
+        "json-bigint": "^1.0.0",
         "qrcode": "^1.5.4",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-syntax-highlighter": "^16.1.0"
     },
     "devDependencies": {
+        "@types/json-bigint": "^1.0.4",
         "@types/react": "^18.3.24",
         "@types/react-dom": "^18.3.7",
         "@types/react-syntax-highlighter": "^15.5.6",

--- a/src/hooks/useRpcUi.tsx
+++ b/src/hooks/useRpcUi.tsx
@@ -5,8 +5,12 @@ import {
     FormGroup,
     TextField,
 } from '@mui/material';
+import JSONbig from 'json-bigint';
 import { useState } from 'react';
 import { useJsonRpc } from '../contexts/JsonRpcContext';
+
+// Integers outside ±(2^53-1) are stored as strings so precision isn't lost.
+const jsonParseSafeIntegers = JSONbig({ storeAsString: true }).parse;
 
 export function useRpcUi() {
     const rpc = useJsonRpc();
@@ -15,9 +19,10 @@ export function useRpcUi() {
 
     const [fingerprint, setFingerprint] = useState(0);
     const [fingerprints, setFingerprints] = useState<string>('');
-    const [amount, setAmount] = useState(0);
+    // Keep as strings so mojo values above 2^53-1 aren't coerced/rounded.
+    const [amount, setAmount] = useState('0');
     const [count, setCount] = useState(1);
-    const [fee, setFee] = useState(0);
+    const [fee, setFee] = useState('0');
     const [number, setNumber] = useState(50);
     const [index, setIndex] = useState(0);
     const [startIndex, setStartIndex] = useState(0);
@@ -169,8 +174,8 @@ export function useRpcUi() {
         ],
         chia_sendTransaction: [
             numberOption('Wallet Id', walletId, setWalletId),
-            numberOption('Amount', amount, setAmount),
-            numberOption('Fee', fee, setFee),
+            stringOption('Amount', amount, setAmount),
+            stringOption('Fee', fee, setFee),
             stringOption('Address', address, setAddress),
             stringOption('Memos', memos, setMemos),
             booleanOption(
@@ -299,13 +304,13 @@ export function useRpcUi() {
                 rpc.createOfferForIds({
                     disableJSONFormatting: disableJsonFormatting,
                     validateOnly,
-                    offer: JSON.parse(offer || '{}'),
-                    driverDict: JSON.parse(driverDict || '{}'),
+                    offer: jsonParseSafeIntegers(offer || '{}'),
+                    driverDict: jsonParseSafeIntegers(driverDict || '{}'),
                 })
             ),
         ],
         chia_cancelOffer: [
-            numberOption('Fee', fee, setFee),
+            stringOption('Fee', fee, setFee),
             stringOption('Trade Id', tradeId, setTradeId),
             booleanOption('Secure', secure, setSecure),
             submitButton('Cancel Offer', () =>
@@ -323,7 +328,7 @@ export function useRpcUi() {
             ),
         ],
         chia_takeOffer: [
-            numberOption('Fee', fee, setFee),
+            stringOption('Fee', fee, setFee),
             stringOption('Offer Data', offerData, setOfferData),
             submitButton('Take Offer', () =>
                 rpc.takeOffer({ fee, offer: offerData })
@@ -348,8 +353,8 @@ export function useRpcUi() {
 
         // CATs
         chia_createNewCATWallet: [
-            numberOption('Amount', amount, setAmount),
-            numberOption('Fee', fee, setFee),
+            stringOption('Amount', amount, setAmount),
+            stringOption('Fee', fee, setFee),
             submitButton('Create New CAT Wallet', () =>
                 rpc.createNewCatWallet({ amount, fee })
             ),
@@ -369,8 +374,8 @@ export function useRpcUi() {
         chia_spendCAT: [
             numberOption('Wallet Id', walletId, setWalletId),
             stringOption('Address', address, setAddress),
-            numberOption('Amount', amount, setAmount),
-            numberOption('Fee', fee, setFee),
+            stringOption('Amount', amount, setAmount),
+            stringOption('Fee', fee, setFee),
             booleanOption(
                 'Wait For Confirmation',
                 waitForConfirmation,
@@ -428,7 +433,7 @@ export function useRpcUi() {
             numberOption('Edition Number', editionNumber, setEditionNumber),
             numberOption('Edition Count', editionCount, setEditionCount),
             stringOption('DID ID', didId, setDidId),
-            numberOption('Fee', fee, setFee),
+            stringOption('Fee', fee, setFee),
             submitButton('Mint NFT', () =>
                 rpc.mintNft({
                     walletId,
@@ -458,7 +463,7 @@ export function useRpcUi() {
             numberOption('Wallet Id', walletId, setWalletId),
             stringOption('NFT Coin Ids', nftCoinIds, setNftCoinIds),
             stringOption('Address', address, setAddress),
-            numberOption('Fee', fee, setFee),
+            stringOption('Fee', fee, setFee),
             submitButton('Transfer NFT', () =>
                 rpc.transferNft({
                     walletId,
@@ -483,8 +488,8 @@ export function useRpcUi() {
 
         // DIDs
         chia_createNewDIDWallet: [
-            numberOption('Amount', amount, setAmount),
-            numberOption('Fee', fee, setFee),
+            stringOption('Amount', amount, setAmount),
+            stringOption('Fee', fee, setFee),
             numberOption(
                 'Number of Backup Dids Needed',
                 backupDidsNeeded,
@@ -514,7 +519,7 @@ export function useRpcUi() {
             stringOption('NFT Coin Ids', nftCoinIds, setNftCoinIds),
             stringOption('Launcher Id', launcherId, setLauncherId),
             stringOption('DID', did, setDid),
-            numberOption('Fee', fee, setFee),
+            stringOption('Fee', fee, setFee),
             submitButton('Set NFT DID', () =>
                 rpc.setNftDid({
                     walletId,

--- a/src/types/rpc/CancelOffer.ts
+++ b/src/types/rpc/CancelOffer.ts
@@ -1,7 +1,7 @@
 export interface CancelOfferRequest {
     tradeId: string;
     secure: boolean;
-    fee: number;
+    fee: string;
 }
 
 export interface CancelOfferResponse {

--- a/src/types/rpc/CreateNewCatWallet.ts
+++ b/src/types/rpc/CreateNewCatWallet.ts
@@ -1,8 +1,8 @@
 import { WalletType } from '../WalletType';
 
 export interface CreateNewCatWalletRequest {
-    amount: number;
-    fee: number;
+    amount: string;
+    fee: string;
 }
 
 export interface CreateNewCatWalletResponse {

--- a/src/types/rpc/CreateNewDidWallet.ts
+++ b/src/types/rpc/CreateNewDidWallet.ts
@@ -1,8 +1,8 @@
 import { WalletType } from '../WalletType';
 
 export interface CreateNewDidWalletRequest {
-    amount: number;
-    fee: number;
+    amount: string;
+    fee: string;
     backupDids: string[];
     numOfBackupIdsNeeded: number;
 }

--- a/src/types/rpc/MintNft.ts
+++ b/src/types/rpc/MintNft.ts
@@ -14,7 +14,7 @@ export interface MintNftRequest {
     editionNumber: number,
     editionCount: number,
     didId: string,
-    fee: number,
+    fee: string,
 }
 
 export type MintNftResponse = NftInfo;

--- a/src/types/rpc/SendTransaction.ts
+++ b/src/types/rpc/SendTransaction.ts
@@ -1,8 +1,8 @@
 import { TransactionRecord } from '../TransactionRecord';
 
 export interface SendTransactionRequest {
-    amount: number;
-    fee: number;
+    amount: string;
+    fee: string;
     address: string;
     walletId?: number;
     waitForConfirmation?: boolean;

--- a/src/types/rpc/SetNftDid.ts
+++ b/src/types/rpc/SetNftDid.ts
@@ -5,7 +5,7 @@ export interface SetNftDidRequest {
     nftLauncherId: string;
     nftCoinIds: string[];
     did: string;
-    fee: number;
+    fee: string;
 }
 
 export interface SetNftDidResponse {

--- a/src/types/rpc/SpendCat.ts
+++ b/src/types/rpc/SpendCat.ts
@@ -3,8 +3,8 @@ import { TransactionRecord } from '../TransactionRecord';
 export interface SpendCatRequest {
     walletId: number;
     address: string;
-    amount: number;
-    fee: number;
+    amount: string;
+    fee: string;
     memos?: string[];
     waitForConfirmation?: boolean;
 }

--- a/src/types/rpc/TakeOffer.ts
+++ b/src/types/rpc/TakeOffer.ts
@@ -2,7 +2,7 @@ import { TradeRecord } from '../TradeRecord';
 
 export interface TakeOfferRequest {
     offer: string;
-    fee: number;
+    fee: string;
 }
 
 export interface TakeOfferResponse {

--- a/src/types/rpc/TransferNft.ts
+++ b/src/types/rpc/TransferNft.ts
@@ -4,7 +4,7 @@ export interface TransferNftRequest {
     walletId: number;
     nftCoinIds: string[];
     targetAddress: string;
-    fee: number;
+    fee: string;
 }
 
 export interface TransferNftResponse {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the wire shape of amount/fee from numbers to strings across many transaction RPCs; correctness depends on the wallet accepting string mojo values, but this aligns with fixing precision bugs for real Chia amounts.
> 
> **Overview**
> Fixes **JavaScript number precision** for Chia mojo amounts and other large integers in the WalletConnect RPC test UI.
> 
> **Amount and fee** are no longer held or sent as `number` types. State defaults and form fields use **strings**, and related request types (`SendTransaction`, `SpendCat`, offers, NFT/DID/CAT flows, etc.) now type `amount`/`fee` as `string` so values above `2^53-1` are not rounded before they reach the wallet.
> 
> **Offer JSON** for `chia_createOfferForIds` is parsed with **`json-bigint`** (`storeAsString: true`) instead of `JSON.parse`, so large integers inside `offer` and `driverDict` stay accurate.
> 
> Adds **`json-bigint`** and **`@types/json-bigint`** as dependencies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ce9561c4d6ea92fdd6cfb555f171dfc21d06c6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->